### PR TITLE
Add Xcode build version fact.

### DIFF
--- a/lib/facter/xcode_build_version.rb
+++ b/lib/facter/xcode_build_version.rb
@@ -1,0 +1,17 @@
+require 'puppet/util/plist' if Puppet.features.cfpropertylist?
+
+xcode_version_plist = '/Applications/Xcode.app/Contents/version.plist'
+
+Facter.add(:xcode_build_version) do
+  confine kernel: 'Darwin'
+  setcode do
+    version = '0000'
+    if File.exist?(xcode_version_plist)
+      plist = Puppet::Util::Plist.read_plist_file(xcode_version_plist)
+      if plist.include? 'ProductBuildVersion'
+        version = plist['ProductBuildVersion']
+      end
+    end
+    version
+  end
+end

--- a/lib/facter/xcode_build_version.rb
+++ b/lib/facter/xcode_build_version.rb
@@ -5,7 +5,7 @@ xcode_version_plist = '/Applications/Xcode.app/Contents/version.plist'
 Facter.add(:xcode_build_version) do
   confine kernel: 'Darwin'
   setcode do
-    version = '0000'
+    version = nil
     if File.exist?(xcode_version_plist)
       plist = Puppet::Util::Plist.read_plist_file(xcode_version_plist)
       if plist.include? 'ProductBuildVersion'


### PR DESCRIPTION
There are some cases where it can be handy to determine which Beta version of Xcode is running on a particular machine. Although the actual "marketing version" (e.g. `Xcode 13.0 Beta 5`) would have been nice, this fact should at least allow us to disambiguate between Xcode builds. 

This is what the `version.plist` looks like:
```xml
user@hostname /Applications/Xcode.app/Contents $ cat version.plist
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>BuildVersion</key>
    <string>9</string>
    <key>CFBundleShortVersionString</key>
    <string>13.0</string>
    <key>CFBundleVersion</key>
    <string>19203.1</string>
    <key>ProductBuildVersion</key>
    <string>13A5192j</string>
    <key>ProjectName</key>
    <string>IDEFrameworks</string>
    <key>SourceVersion</key>
    <string>19203001000000000</string>
</dict>
</plist>
```